### PR TITLE
Change how Task is created in XunitWorkerThread

### DIFF
--- a/src/common/XunitWorkerThread_Task.cs
+++ b/src/common/XunitWorkerThread_Task.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Xunit.Sdk
@@ -9,18 +10,20 @@ namespace Xunit.Sdk
 
         public XunitWorkerThread(Action threadProc)
         {
-            task = new Task(() => threadProc());
-            task.Start();
+            task = Task.Factory.StartNew(threadProc, 
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, 
+                TaskScheduler.Default);
         }
 
         public void Join()
         {
-            task.Wait();
+            task.GetAwaiter().GetResult();
         }
 
         public static void QueueUserWorkItem(Action backgroundTask)
         {
-            Task.Run(() => backgroundTask());
+            Task.Run(backgroundTask);
         }
     }
 }


### PR DESCRIPTION
When a MaxConcurrencySyncContext or MaxConcurrencyTaskScheduler is
created, it spins up N XunitWorkerThread instances, where by default
N is Environment.ProcessCount; this is also the default number of threads
that the thread pool will quickly ramp up to.  Tests are then queued
to execute on these workers, which are effectively consuming all of the
default thread pool threads sitting blocked waiting for work to arrive.
If a test then itself queues work to the thread pool, e.g. via Task.Run,
it's unlikely there will be any thread left to run it.  This means the
thread pool must inject additional threads, which it will eventually
do, but potentially slowly, leading to potentially long delays in test
execution.

This commit changes XunitWorkerThread_Task.cs to specify
TaskCreationOptions.LongRunning for the task that's created.  This
tells the default scheduler (the thread pool) that the task is going
to be running some longer running work (it's going to be blocking
waiting for work to arrive) and that the scheduler should optimize
around that; currently, the scheduler just responds to that by creating
a dedicated thread for the task.  This avoids the aforementioned
bottleneck, and is what the more generally-used
XunitWorkerThread_Thread.cs does any way.

The change also makes a few more tweaks to the file, including being
explicit about which scheduler to target (in case there's an ambient one
that would otherwise be used), preventing any tasks created in a test from
using AttachedToParent to delay this task's completion, and fixing up some
unnecessary closures.
